### PR TITLE
Improve interoperability, add display information to input IP address, add color overlay

### DIFF
--- a/project.py
+++ b/project.py
@@ -5,6 +5,10 @@ from maltego_trx.registry import register_transform_function, register_transform
 from maltego_trx.server import app, application
 from maltego_trx.handler import handle_run
 
+import maltego_trx.maltego
+# hotfix until adjusted in upstream
+maltego_trx.maltego.DISP_INFO_TEMPLATE = "<Label Name=\"%(name)s\" Type=\"text/html\"><![CDATA[%(content)s]]></Label>"
+
 register_transform_classes(transforms)
 
 handle_run(__name__, sys.argv, app)

--- a/transforms/GreyNoiseCommunityIPLookup.py
+++ b/transforms/GreyNoiseCommunityIPLookup.py
@@ -1,6 +1,26 @@
 from greynoise import GreyNoise
-from maltego_trx.entities import Person
+from maltego_trx.overlays import OverlayPosition, OverlayType
+from maltego_trx.maltego import MaltegoEntity
 from maltego_trx.transform import DiscoverableTransform
+
+
+def add_display_info(ip_ent: MaltegoEntity, classification, last_seen, link):
+    link_text = "" if not link else f'<h3><a href="{link}">Open in GreyNoise</a></h3> <br/>'
+    classification_text = "" if not classification else f"GreyNoise classification for IP: {classification}<br/>"
+    last_seen_text = "" if not last_seen else f"Last seen by GreyNoise: {last_seen}"
+    ip_ent.addDisplayInformation(
+        f"{link_text}{classification_text}{last_seen_text}",
+        "GreyNoise Community"
+    )
+    colour = None
+    if classification == "benign":
+        colour = "green"
+    elif classification == "malicious":
+        colour = "red"
+
+    if colour:
+        ip_ent.addProperty(fieldName="gn_color", displayName="GreyNoise color", value=color, matchingRule="loose")
+        ip_ent.addOverlay(propertyName="gn_color", position=OverlayPosition.NORTH_WEST, overlayType=OverlayType.COLOUR)
 
 
 class GreyNoiseCommunityIPLookup(DiscoverableTransform):
@@ -12,22 +32,28 @@ class GreyNoiseCommunityIPLookup(DiscoverableTransform):
             integration_name="maltego-community-v1.0.0",
             offering="community",
         )
+        input_ip = response.addEntity("maltego.IPv4Address", request.Value)
         try:
             resp = api_client.ip(request.Value)
-            if resp["noise"]:
-                response.addEntity("greynoise.noise", "Noise Detected")
-                response.addEntity(Person, resp["name"])
-                response.addEntity("greynoise.classification", resp["classification"])
-                response.addEntity("greynoise.last_seen", resp["last_seen"])
-                response.addEntity("greynoise.link", resp["link"])
-            elif resp["riot"]:
+            if resp["noise"] or resp["riot"]:
+                if resp["noise"]:
+                    response.addEntity("greynoise.noise", "Noise Detected")
                 if resp["riot"]:
                     response.addEntity("greynoise.riot", "Benign Service Detected")
-                    response.addEntity(Person, resp["name"])
-                    response.addEntity("greynoise.last_seen", resp["last_seen"])
-                    response.addEntity("greynoise.link", resp["link"])
+                response.addEntity("maltego.Alias", resp["name"])
+                response.addEntity("greynoise.classification", resp["classification"])
+                response.addEntity("maltego.DateTime", resp["last_seen"])
+                url = response.addEntity("maltego.URL", resp["link"])
+                url.addProperty(
+                    fieldName="short-title", displayName="GreyNoise color", value=resp["link"], matchingRule="strict"
+                )
+                url.addProperty(
+                    fieldName="url", displayName="GreyNoise color", value=resp["link"], matchingRule="strict"
+                )
             else:
                 response.addEntity("greynoise.noise", "No Noise Detected")
-                response.addUIMessage("This IP address hasn't been seen by GreyNoise")
+                response.addUIMessage(f"The IP address {request.Value} hasn't been seen by GreyNoise.")
+
+            add_display_info(input_ip, resp.get("classification"), resp.get("last_seen"), resp.get("link"))
         except Exception as e:
             response.addUIMessage(e)

--- a/transforms/GreyNoiseCommunityIPLookup.py
+++ b/transforms/GreyNoiseCommunityIPLookup.py
@@ -14,12 +14,12 @@ def add_display_info(ip_ent: MaltegoEntity, classification, last_seen, link):
     )
     colour = None
     if classification == "benign":
-        colour = "green"
+        colour = "#45e06f"
     elif classification == "malicious":
-        colour = "red"
+        colour = "#eb4d4b"
 
     if colour:
-        ip_ent.addProperty(fieldName="gn_color", displayName="GreyNoise color", value=color, matchingRule="loose")
+        ip_ent.addProperty(fieldName="gn_color", displayName="GreyNoise color", value=colour, matchingRule="loose")
         ip_ent.addOverlay(propertyName="gn_color", position=OverlayPosition.NORTH_WEST, overlayType=OverlayType.COLOUR)
 
 
@@ -39,7 +39,7 @@ class GreyNoiseCommunityIPLookup(DiscoverableTransform):
                 if resp["noise"]:
                     response.addEntity("greynoise.noise", "Noise Detected")
                 if resp["riot"]:
-                    response.addEntity("greynoise.riot", "Benign Service Detected")
+                    response.addEntity("greynoise.noise", "Benign Service Detected")
                 response.addEntity("maltego.Alias", resp["name"])
                 response.addEntity("greynoise.classification", resp["classification"])
                 response.addEntity("maltego.DateTime", resp["last_seen"])

--- a/transforms/GreyNoiseCommunityIPLookup.py
+++ b/transforms/GreyNoiseCommunityIPLookup.py
@@ -5,8 +5,13 @@ from maltego_trx.transform import DiscoverableTransform
 
 
 def add_display_info(ip_ent: MaltegoEntity, classification, last_seen, link, name):
-    link_text = "" if not link else f'<h3><a href="{link}">Open in GreyNoise</a></h3> <br/>'
-    classification_text = "" if not classification else f"GreyNoise classification for IP: {classification}<br/>"
+    link_text = ""
+    if link:
+        link_text = f'<h3><a href="{link}">Open in GreyNoise</a></h3> <br/>'
+
+    classification_text = ""
+    if classification:
+        classification_text = f"GreyNoise classification for IP: {classification}<br/>"
 
     name_text = ""
     if name and name != "unknown":
@@ -16,7 +21,7 @@ def add_display_info(ip_ent: MaltegoEntity, classification, last_seen, link, nam
 
     ip_ent.addDisplayInformation(
         f"{link_text}{classification_text}{name_text}{last_seen_text}",
-        "GreyNoise Community"
+        "GreyNoise Community",
     )
     colour = None
     if classification == "benign":
@@ -25,8 +30,17 @@ def add_display_info(ip_ent: MaltegoEntity, classification, last_seen, link, nam
         colour = "#eb4d4b"
 
     if colour:
-        ip_ent.addProperty(fieldName="gn_color", displayName="GreyNoise color", value=colour, matchingRule="loose")
-        ip_ent.addOverlay(propertyName="gn_color", position=OverlayPosition.NORTH_WEST, overlayType=OverlayType.COLOUR)
+        ip_ent.addProperty(
+            fieldName="gn_color",
+            displayName="GreyNoise color",
+            value=colour,
+            matchingRule="loose",
+        )
+        ip_ent.addOverlay(
+            propertyName="gn_color",
+            position=OverlayPosition.NORTH_WEST,
+            overlayType=OverlayType.COLOUR,
+        )
 
 
 class GreyNoiseCommunityIPLookup(DiscoverableTransform):
@@ -51,17 +65,29 @@ class GreyNoiseCommunityIPLookup(DiscoverableTransform):
                 response.addEntity("maltego.DateTime", resp["last_seen"])
                 url = response.addEntity("maltego.URL", resp["link"])
                 url.addProperty(
-                    fieldName="short-title", displayName="GreyNoise color", value=resp["link"], matchingRule="strict"
+                    fieldName="short-title",
+                    displayName="GreyNoise color",
+                    value=resp["link"],
+                    matchingRule="strict",
                 )
                 url.addProperty(
-                    fieldName="url", displayName="GreyNoise color", value=resp["link"], matchingRule="strict"
+                    fieldName="url",
+                    displayName="GreyNoise color",
+                    value=resp["link"],
+                    matchingRule="strict",
                 )
             else:
                 response.addEntity("greynoise.noise", "No Noise Detected")
-                response.addUIMessage(f"The IP address {request.Value} hasn't been seen by GreyNoise.")
+                response.addUIMessage(
+                    f"The IP address {request.Value} hasn't been seen by GreyNoise."
+                )
 
             add_display_info(
-                input_ip, resp.get("classification"), resp.get("last_seen"), resp.get("link"), resp.get("name")
+                input_ip,
+                resp.get("classification"),
+                resp.get("last_seen"),
+                resp.get("link"),
+                resp.get("name"),
             )
         except Exception as e:
             response.addUIMessage(e)

--- a/transforms/GreyNoiseCommunityIPLookup.py
+++ b/transforms/GreyNoiseCommunityIPLookup.py
@@ -4,12 +4,18 @@ from maltego_trx.maltego import MaltegoEntity
 from maltego_trx.transform import DiscoverableTransform
 
 
-def add_display_info(ip_ent: MaltegoEntity, classification, last_seen, link):
+def add_display_info(ip_ent: MaltegoEntity, classification, last_seen, link, name):
     link_text = "" if not link else f'<h3><a href="{link}">Open in GreyNoise</a></h3> <br/>'
     classification_text = "" if not classification else f"GreyNoise classification for IP: {classification}<br/>"
+
+    name_text = ""
+    if name and name != "unknown":
+        name_text = f"GreyNoise attribution: {name}<br/>"
+
     last_seen_text = "" if not last_seen else f"Last seen by GreyNoise: {last_seen}"
+
     ip_ent.addDisplayInformation(
-        f"{link_text}{classification_text}{last_seen_text}",
+        f"{link_text}{classification_text}{name_text}{last_seen_text}",
         "GreyNoise Community"
     )
     colour = None
@@ -54,6 +60,8 @@ class GreyNoiseCommunityIPLookup(DiscoverableTransform):
                 response.addEntity("greynoise.noise", "No Noise Detected")
                 response.addUIMessage(f"The IP address {request.Value} hasn't been seen by GreyNoise.")
 
-            add_display_info(input_ip, resp.get("classification"), resp.get("last_seen"), resp.get("link"))
+            add_display_info(
+                input_ip, resp.get("classification"), resp.get("last_seen"), resp.get("link"), resp.get("name")
+            )
         except Exception as e:
             response.addUIMessage(e)


### PR DESCRIPTION
Updated examples:

![Screenshot 2021-04-07 at 17 45 40](https://user-images.githubusercontent.com/876919/113895259-131fbd80-97c9-11eb-8c93-4eb3d4f48b5d.png)

Main changes:
- return maltego.URL instead of greynoise.link
- add the URL, last_seen status and classification to the display information
- add a red or green indicator if noise was detected (green means benign noise, red means malicious)